### PR TITLE
Feat: Speed editor jog and battery updates

### DIFF
--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -159,6 +159,10 @@ export class BlackmagicControllerBase extends EventEmitter<BlackmagicControllerE
 		return this.#propertiesService.getBatteryLevel()
 	}
 
+	public async getBatteryCharging(): Promise<boolean | null> {
+		return this.#propertiesService.getBatteryCharging()
+	}
+
 	public async getFirmwareVersion(): Promise<string> {
 		return this.#propertiesService.getFirmwareVersion()
 	}
@@ -242,5 +246,9 @@ export class BlackmagicControllerBase extends EventEmitter<BlackmagicControllerE
 
 	public async clearPanel(): Promise<void> {
 		await this.#ledService.clearPanel()
+	}
+
+	public async setJogMode(mode: number): Promise<void> {
+		return this.#propertiesService.setJogMode(mode)
 	}
 }

--- a/packages/core/src/models/resolve-speed-editor.ts
+++ b/packages/core/src/models/resolve-speed-editor.ts
@@ -87,20 +87,21 @@ export function ResolveSpeedEditorFactory(
 		deviceProperties: resolveSpeedEditorProperties,
 		events,
 		properties: new DefaultPropertiesService(device, {
-			batteryReportId: null,
-			firmwareReportId: 1,
-			serialReportId: 8,
+			batteryReportId: 0x07,
+			firmwareReportId: 0x01,
+			jogReportId: 0x03,
+			serialReportId: 0x08,
 		}),
 		inputService: new DefaultInputService(resolveSpeedEditorProperties, events, {
 			buttonReportId: 0x04,
 			jogReportId: 0x03,
-			batteryReportId: 0x06,
+			batteryReportId: 0x07, //not used but provided for completeness
 		}),
-		led: new ResolveShuttleLedService(device),
+		led: new ResolveSpeedEditorLedService(device),
 	})
 }
 
-class ResolveShuttleLedService implements BlackmagicControllerLedService {
+class ResolveSpeedEditorLedService implements BlackmagicControllerLedService {
 	readonly #device: HIDDevice
 
 	#primaryBuffer = new LedBuffer(0x02, 5)

--- a/packages/core/src/proxy.ts
+++ b/packages/core/src/proxy.ts
@@ -67,11 +67,19 @@ export class BlackmagicControllerProxy implements BlackmagicController {
 	public async getBatteryLevel(): Promise<number | null> {
 		return this.device.getBatteryLevel()
 	}
+	public async getBatteryCharging(): Promise<boolean | null> {
+		return this.device.getBatteryCharging()
+	}
 	public async getFirmwareVersion(): Promise<string> {
 		return this.device.getFirmwareVersion()
 	}
 	public async getSerialNumber(): Promise<string> {
 		return this.device.getSerialNumber()
+	}
+	public async setJogMode(
+		...args: Parameters<BlackmagicController['setJogMode']>
+	): ReturnType<BlackmagicController['setJogMode']> {
+		return this.device.setJogMode(...args)
 	}
 
 	/**

--- a/packages/core/src/services/properties/default.ts
+++ b/packages/core/src/services/properties/default.ts
@@ -6,6 +6,14 @@ export interface DefaultPropertiesServiceOptions {
 	batteryReportId: number | null
 	firmwareReportId: number
 	serialReportId: number
+	jogReportId?: number
+}
+
+export enum BlackmagicControllerJogModes {
+	RELATIVE_0 = 0, //Velocity mode 0. Stationary values between -1440 and 1440. Full range c. -250000 to +250000
+	ABSOLUTE = 1, //Three-step mode: -4096 / 0 / +4096 in half a turn. No in-between values
+	RELATIVE_2 = 2, //Appears same as RELATIVE_0
+	ABSOLUTE_DEADZERO = 3, //Appears same as ABSOLUTE
 }
 
 export class DefaultPropertiesService implements PropertiesService {
@@ -19,9 +27,14 @@ export class DefaultPropertiesService implements PropertiesService {
 
 	public async getBatteryLevel(): Promise<number | null> {
 		if (this.#options.batteryReportId === null) return null
-
 		const val = await this.#device.getFeatureReport(this.#options.batteryReportId, 3)
 		return val[2] / 100
+	}
+
+	public async getBatteryCharging(): Promise<boolean | null> {
+		if (this.#options.batteryReportId === null) return null
+		const val = await this.#device.getFeatureReport(this.#options.batteryReportId, 3)
+		return val[1] == 1
 	}
 
 	public async getFirmwareVersion(): Promise<string> {
@@ -35,5 +48,11 @@ export class DefaultPropertiesService implements PropertiesService {
 	public async getSerialNumber(): Promise<string> {
 		const val = await this.#device.getFeatureReport(this.#options.serialReportId, 33)
 		return new TextDecoder('ascii').decode(val.subarray(1))
+	}
+
+	public async setJogMode(mode: BlackmagicControllerJogModes): Promise<void> {
+		const buffer = new Uint8Array([this.#options.jogReportId ?? 0x03, mode, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+		await this.#device.sendReports([buffer])
+		return
 	}
 }

--- a/packages/core/src/services/properties/interface.ts
+++ b/packages/core/src/services/properties/interface.ts
@@ -1,7 +1,11 @@
 export interface PropertiesService {
 	getBatteryLevel(): Promise<number | null>
 
+	getBatteryCharging(): Promise<boolean | null>
+
 	getFirmwareVersion(): Promise<string>
 
 	getSerialNumber(): Promise<string>
+
+	setJogMode(mode: number): Promise<void>
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,8 @@ export type BlackmagicControllerEvents = {
 	down: [control: BlackmagicControllerButtonControlDefinition]
 	up: [control: BlackmagicControllerButtonControlDefinition]
 	tbar: [control: BlackmagicControllerTBarControlDefinition, percent: number]
-	jog: [control: BlackmagicControllerJogControlDefinition, velocity: number]
+	jogVelocity: [control: BlackmagicControllerJogControlDefinition, velocity: number]
+	jogMode: [control: BlackmagicControllerJogControlDefinition, mode: number]
 	batteryLevel: [percent: number]
 	error: [err: unknown]
 }
@@ -40,6 +41,11 @@ export interface BlackmagicController extends EventEmitter<BlackmagicControllerE
 	 * Get the current battery level of the controller, if supported
 	 */
 	getBatteryLevel(): Promise<number | null>
+
+	/**
+	 * Get the battery charging state of the controller, if supported
+	 */
+	getBatteryCharging(): Promise<boolean | null>
 
 	/**
 	 * Fills a rgb button with a solid color.
@@ -92,6 +98,13 @@ export interface BlackmagicController extends EventEmitter<BlackmagicControllerE
 	 * Get serial number of the controller
 	 */
 	getSerialNumber(): Promise<string>
+
+	/**
+	 * 	Set the jog wheel mode
+	 *
+	 * @param {number} mode Jog mode
+	 */
+	setJogMode(mode: number): Promise<void>
 }
 
 export interface BlackmagicControllerSetButtonColorValue {

--- a/packages/node/examples/resolve-speed-editor-test.js
+++ b/packages/node/examples/resolve-speed-editor-test.js
@@ -1,20 +1,51 @@
 // @ts-check
 import { BlackmagicControllerModelId, listBlackmagicControllers, openBlackmagicController } from '../dist/index.js'
 
-const devices = await listBlackmagicControllers()
-const selectedDev = devices.find((d) => d.model === BlackmagicControllerModelId.DaVinciResolveSpeedEditor)
-if (!selectedDev) throw new Error('No device found')
+async function findAndOpenPanel(retryCount = 100, retryInterval = 2000) {
+	for (let attempt = 1; attempt <= retryCount; attempt++) {
+		console.log(`Attempt ${attempt}/${retryCount}: Searching for DaVinci Resolve Speed Editor...`)
 
-const panel = await openBlackmagicController(selectedDev.path)
+		const devices = await listBlackmagicControllers()
+		const selectedDev = devices.find((d) => d.model === BlackmagicControllerModelId.DaVinciResolveSpeedEditor)
+
+		if (selectedDev) {
+			console.log(`----- Found DaVinci Resolve Speed Editor -----`)
+			return await openBlackmagicController(selectedDev.path)
+		}
+
+		if (attempt < retryCount) {
+			console.log(`No device found. Retrying in ${retryInterval / 1000} seconds...`)
+			await new Promise((resolve) => setTimeout(resolve, retryInterval))
+		}
+	}
+
+	throw new Error(`No DaVinci Resolve Speed Editor found after ${retryCount} attempts`)
+}
+
+const panel = await findAndOpenPanel()
 
 if (panel.MODEL !== BlackmagicControllerModelId.DaVinciResolveSpeedEditor)
 	throw new Error('This test is for the DaVinci Resolve Speed Editor only')
 
 await panel.clearPanel()
 
-console.log(`opened panel ${panel.MODEL}`)
-console.log('serial', await panel.getSerialNumber())
-console.log('firmware', await panel.getFirmwareVersion())
+console.log(`Opened panel ${panel.MODEL}`)
+console.log('Panel serial number is', await panel.getSerialNumber())
+console.log('Panel firmware version is', await panel.getFirmwareVersion())
+
+const batteryLevel = await panel.getBatteryLevel()
+if (batteryLevel !== null) {
+	console.log(`Battery level: ${batteryLevel * 100}%`)
+}
+
+const batteryCharging = await panel.getBatteryCharging()
+if (batteryCharging !== null) {
+	console.log(`Battery is charging: ${batteryCharging ? 'true' : 'false'}`)
+}
+
+// Set jog wheel to velocity mode
+await panel.setJogMode(0) // 0 = velocity mode, 1 = shuttle mode
+console.log('Jog mode is set to 0 (velocity)')
 
 let nextColor = 0
 
@@ -60,14 +91,10 @@ panel.on('tbar', (control, percent) => {
 	console.log(`T-bar "${control.id}" moved to ${percent * 100}%`)
 })
 
-panel.on('jog', (control, velocity) => {
-	console.log(`Jog "${control.id}" velocity ${velocity}`)
+panel.on('jogVelocity', (control, velocity) => {
+	console.log(`Jog ${control.id} velocity ${velocity}`)
 })
 
 panel.on('batteryLevel', (percent) => {
 	console.log(`Battery level ${percent * 100}%`)
-})
-
-panel.on('error', (error) => {
-	console.error(error)
 })


### PR DESCRIPTION
Got a Speed Editor recently, so been playing with this repository - along with the code from https://github.com/smunaut/blackmagic-misc/tree/master

Added a few extra features for Speed Editor only:

- **Added battery level (and charging status) reporting**
- **Added Set Jog Mode**
I think jog mode might be persistent, so I've added the ability to set it to the default (velocity, mode 0) if required. The other option is a basic three-step wheel for (presumably) back - stop - forward, but it provides no intermediate values and so is not really much use.

- **Jog velocity scaling**
Jog velocity is a LE32 integer - but the fastest I could get it to spin corresponds with about ±350,000. For consistency and repeatability I've clamped the values to -350,000 to +350,000 and then scaled this to range -1024 to +1024

- **Jog wheel anti-drift**
The jog wheel does not report a 0 velocity when stopped. It's often in range -1440 to +1440 but I've seen some very high values (c. 20,000) if it's spun quick then stopped abruptly. To avoid drift, I've added a 100ms timeout that resets jog wheel velocity to zero  when no further reports are received. 
The 100ms delay seems about right - on my machine I get a report every c. 20ms when moving the jog wheel, but I guess that might change depending on the system.